### PR TITLE
store-service 엔티티 클래스 설계 및 연관관계 설정

### DIFF
--- a/store-service/src/main/java/com/justpickup/storeservice/domain/category/entity/Category.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/category/entity/Category.java
@@ -1,0 +1,46 @@
+package com.justpickup.storeservice.domain.category.entity;
+
+import com.justpickup.storeservice.domain.item.entity.Item;
+import com.justpickup.storeservice.domain.store.entity.Store;
+import com.justpickup.storeservice.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.util.List;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Table(name = "category")
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "category_id")
+    private Long id;
+
+    private String name;
+
+    private Integer orders;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @OneToMany(mappedBy = "category")
+    private List<Item> items;
+
+    // == 연관관계 편의 메소드 == //
+    public void setStore(Store store) {
+        this.store = store;
+        store.getCategories().add(this);
+    }
+
+    public void addItem(Item item) {
+        items.add(item);
+        item.setCategory(this);
+    }
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/favoritestore/entity/FavoriteStore.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/favoritestore/entity/FavoriteStore.java
@@ -1,0 +1,28 @@
+package com.justpickup.storeservice.domain.favoritestore.entity;
+
+import com.justpickup.storeservice.domain.store.entity.Store;
+import com.justpickup.storeservice.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Table(name = "favorite_store")
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteStore extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "favorite_store_id")
+    private Long id;
+
+    //== user-service.user pk ==//
+    private Long userId;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/item/entity/Item.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/item/entity/Item.java
@@ -1,0 +1,73 @@
+package com.justpickup.storeservice.domain.item.entity;
+
+import com.justpickup.storeservice.domain.category.entity.Category;
+import com.justpickup.storeservice.domain.itemoption.entity.ItemOption;
+import com.justpickup.storeservice.domain.store.entity.Store;
+import com.justpickup.storeservice.global.entity.BaseEntity;
+import com.justpickup.storeservice.global.entity.Photo;
+import com.justpickup.storeservice.global.entity.Yn;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.util.List;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Table(name = "item")
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Item extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "item_id")
+    private Long id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Yn salesYn;
+
+    private Long price;
+
+    @Embedded
+    private Photo photo;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @OneToMany(mappedBy = "item")
+    private List<ItemOption> itemOptions;
+
+    // == 연관관계 편의 메소드 ==//
+    public void addItemOption(ItemOption itemOption) {
+        itemOptions.add(itemOption);
+        itemOption.setItem(this);
+    }
+
+    public void setStore(Store store) {
+        this.store = store;
+        store.getItems().add(this);
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+        category.getItems().add(this);
+    }
+
+    // == 생성 메소드 == //
+    public static Item createdItem(Category category, Store store, List<ItemOption> itemOptions) {
+        Item item = new Item();
+        item.setCategory(category);
+        item.setStore(store);
+        itemOptions.forEach(item::addItemOption);
+        return item;
+    }
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/itemoption/entity/ItemOption.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/itemoption/entity/ItemOption.java
@@ -1,0 +1,38 @@
+package com.justpickup.storeservice.domain.itemoption.entity;
+
+import com.justpickup.storeservice.domain.item.entity.Item;
+import com.justpickup.storeservice.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Table(name = "item_option")
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemOption extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "item_option_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private OptionType optionType;
+
+    private Long price;
+
+    private String name;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    // == 연관관계 편의 메소드 == //
+    public void setItem(Item item) {
+        this.item = item;
+        item.getItemOptions().add(this);
+    }
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/itemoption/entity/OptionType.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/itemoption/entity/OptionType.java
@@ -1,0 +1,5 @@
+package com.justpickup.storeservice.domain.itemoption.entity;
+
+public enum OptionType {
+    REQUIRED, OTHER
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/map/entity/Map.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/map/entity/Map.java
@@ -1,0 +1,17 @@
+package com.justpickup.storeservice.domain.map.entity;
+
+import com.justpickup.storeservice.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "map")
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Map extends BaseEntity {
+    @Id @GeneratedValue
+    @Column(name = "map_id")
+    private Long id;
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/review/entity/Review.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/review/entity/Review.java
@@ -1,0 +1,44 @@
+package com.justpickup.storeservice.domain.review.entity;
+
+import com.justpickup.storeservice.domain.reviewreply.entity.ReviewReply;
+import com.justpickup.storeservice.domain.store.entity.Store;
+import com.justpickup.storeservice.global.entity.BaseEntity;
+import com.justpickup.storeservice.global.entity.Photo;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Table(name = "review")
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "review_id")
+    private Long id;
+
+    private String content;
+
+    private Integer starRating;
+
+    @Embedded
+    private Photo photo;
+
+    //== user-service.user pk ==//
+    private Long userId;
+
+    //== order-service.order pk ==//
+    private Long orderId;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "review_reply_id")
+    private ReviewReply reviewReply;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/reviewreply/entity/ReviewReply.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/reviewreply/entity/ReviewReply.java
@@ -1,0 +1,20 @@
+package com.justpickup.storeservice.domain.reviewreply.entity;
+
+import com.justpickup.storeservice.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "review_reply")
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewReply extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "review_reply_id")
+    private Long id;
+
+    private String content;
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/store/entity/Store.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/store/entity/Store.java
@@ -1,0 +1,63 @@
+package com.justpickup.storeservice.domain.store.entity;
+
+import com.justpickup.storeservice.domain.category.entity.Category;
+import com.justpickup.storeservice.domain.item.entity.Item;
+import com.justpickup.storeservice.domain.map.entity.Map;
+import com.justpickup.storeservice.global.entity.Address;
+import com.justpickup.storeservice.global.entity.BaseEntity;
+import com.justpickup.storeservice.global.entity.Photo;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Table(name = "store")
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Store extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "store_id")
+    private Long id;
+
+    private LocalDateTime businessStartTime;
+
+    private LocalDateTime businessEndTime;
+
+    private String phoneNumber;
+
+    @Embedded
+    private Address address;
+
+    @Embedded
+    private Photo photo;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "map_id")
+    private Map map;
+
+    //== user-service.user pk ==//
+    private Long userId;
+
+    @OneToMany(mappedBy = "store")
+    private List<Category> categories;
+
+    @OneToMany(mappedBy = "store")
+    private List<Item> items;
+
+    // == 연관관계 편의 메소드 == //
+    public void addCategory(Category category) {
+        categories.add(category);
+        category.setStore(this);
+    }
+
+    public void addItem(Item item) {
+        items.add(item);
+        item.setStore(this);
+    }
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/global/entity/Address.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/global/entity/Address.java
@@ -1,0 +1,17 @@
+package com.justpickup.storeservice.global.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor @Getter
+public class Address {
+    private String city;
+    private String street;
+    private String zipcode;
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/global/entity/BaseEntity.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/global/entity/BaseEntity.java
@@ -1,0 +1,13 @@
+package com.justpickup.storeservice.global.entity;
+
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+public class BaseEntity {
+
+    private Long createdBy;
+    private LocalDateTime createdAt;
+    private Long lastModifiedBy;
+    private LocalDateTime lastModifiedAt;
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/global/entity/Photo.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/global/entity/Photo.java
@@ -1,0 +1,20 @@
+package com.justpickup.storeservice.global.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor @Getter
+public class Photo {
+
+    @Column(name = "photo_path")
+    private String path;
+    @Column(name = "photo_name")
+    private String name;
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/global/entity/Yn.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/global/entity/Yn.java
@@ -1,0 +1,5 @@
+package com.justpickup.storeservice.global.entity;
+
+public enum Yn {
+    Y, N
+}

--- a/store-service/src/main/resources/application.yml
+++ b/store-service/src/main/resources/application.yml
@@ -8,9 +8,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-    generate-ddl: true
-    show-sql: true
-    format_sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
     open-in-view: false
     default_batch_fetch_size: 1000
 


### PR DESCRIPTION
## What is this PR? :mag:
- 하기의 ERD와 객체 연관관계를 기준으로 엔티티 설계를 진행하였습니다.
- 양방향 연관관계 및 연관관계 편의 메소드가 구현되어 있습니다.

## Changes :memo:
- 엔티티 클래스가 추가되었습니다.
  - 엔티티 클래스 추가
  - 데이터베이스 테이블 추가
- 편의 메소드 추가
  - 연관관계 편의 메소드(양방향) 추가
  - Item 테이블 생성 메소드 추가
- application.yml 파일 수정
  - hibernate의 ddl 포맷 관련 설정이 올바르도록 수정되었습니다.

## Screenshot :camera:
기능|스크린샷|
|------|---|
|ERD|![image](https://user-images.githubusercontent.com/72686708/151130829-c7ceb677-e77e-4bfd-87b2-e209fa624f8b.png)|
|테이블 리스트|![image](https://user-images.githubusercontent.com/72686708/151131006-9cb8c07b-ff20-457b-83b3-d9055349f3f4.png)|


## Test Checklist ☑️
- [x] 서버 기동 시 테이블 생성 여부
- [x] 엔티티 변수명과 테이블 컬럼명의 일치 여부  