### PR TITLE
feat(owner-vue, store-service): 카테고리에서 바로 item리스트 view

### DIFF
--- a/owner-vue/src/views/Category.vue
+++ b/owner-vue/src/views/Category.vue
@@ -24,10 +24,10 @@
     <v-expansion-panels style="display: block">
       <draggable v-model="categoryList" id="categoryEl" >
         <v-expansion-panel
-            v-for="item in categoryList" :key="item.categoryId" class="category-item" :data-id="item.categoryId"
+            v-for="category in categoryList" :key="category.categoryId" class="category-item" :data-id="category.categoryId"
         >
           <v-expansion-panel-header >
-            <span contenteditable="true" >{{ item.name }}</span>
+            <span contenteditable="true" >{{ category.name }}</span>
 
             <template v-slot:actions>
               <v-btn
@@ -39,7 +39,13 @@
 
           </v-expansion-panel-header>
           <v-expansion-panel-content>
-            item-list
+
+            <v-list-item v-for=" item in category.items" :key="item.id" >
+              <v-list-item-content>
+                <v-list-item-title> {{item.name}}</v-list-item-title>
+              </v-list-item-content>
+            </v-list-item>
+
           </v-expansion-panel-content>
         </v-expansion-panel>
       </draggable>

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/category/dto/CategoryDto.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/category/dto/CategoryDto.java
@@ -2,11 +2,13 @@ package com.justpickup.storeservice.domain.category.dto;
 
 import com.justpickup.storeservice.domain.category.entity.Category;
 import com.justpickup.storeservice.domain.category.web.CategoryController;
+import com.justpickup.storeservice.domain.item.dto.ItemDto;
 import com.justpickup.storeservice.domain.item.entity.Item;
 import com.justpickup.storeservice.domain.store.entity.Store;
 import lombok.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -18,14 +20,16 @@ public class CategoryDto {
     private String name;
     private Integer order;
     private Store store;
-    private List<Item> items;
+    private List<ItemDto> items;
 
     public CategoryDto(Category category) {
         this.id = category.getId();
         this.name = category.getName();
         this.order = category.getOrder();
         this.store = category.getStore();
-        this.items = category.getItems();
+        this.items = category.getItems().stream()
+                .map(ItemDto::createItemDto)
+                .collect(Collectors.toList());
     }
 
     public CategoryDto(CategoryController.PutCategoryRequest.Category category) {

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/category/web/CategoryController.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/category/web/CategoryController.java
@@ -2,6 +2,7 @@ package com.justpickup.storeservice.domain.category.web;
 
 import com.justpickup.storeservice.domain.category.dto.CategoryDto;
 import com.justpickup.storeservice.domain.category.service.CategoryService;
+import com.justpickup.storeservice.domain.item.dto.ItemDto;
 import com.justpickup.storeservice.global.dto.Result;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
@@ -35,16 +36,33 @@ public class CategoryController {
     }
 
 
+
     @Data
     static class CategoryResponse{
         private Long categoryId;
         private String name;
         private Integer order;
+        private List<ItemResponse> items;
 
         public  CategoryResponse (CategoryDto categoryDto){
             this.categoryId = categoryDto.getId();
             this.name= categoryDto.getName();
             this.order= categoryDto.getOrder();
+            this.items = categoryDto.getItems().stream()
+                    .map(ItemResponse::new)
+                    .collect(Collectors.toList());
+        }
+
+        @Data
+        static class ItemResponse{
+            private Long id;
+            private String name;
+
+            public ItemResponse(ItemDto itemDto) {
+                this.id = itemDto.getId();
+                this.name = itemDto.getName();
+            }
+
         }
     }
 


### PR DESCRIPTION
owner-vue에 item view 개발,
store-service에서 item을 Response하도록 수정

## What is this PR? :mag:
category List에서 item List 뿌려주도록 수정

## Changes :memo:
내용
- 항목 


## Screenshot :camera:
기능|스크린샷|
|------|---|
|화면|<img width="897" alt="image" src="https://user-images.githubusercontent.com/48042490/155465797-0b1ef9eb-bab7-4816-9a18-b68bd1c3fd69.png">|

