### PR TITLE
점주 로그인, axios interceptor, vue router, JWT 인증, access token url mapping

### DIFF
--- a/owner-apigateway-service/src/main/java/com/justpickup/ownerapigatewayservice/OwnerApigatewayServiceApplication.java
+++ b/owner-apigateway-service/src/main/java/com/justpickup/ownerapigatewayservice/OwnerApigatewayServiceApplication.java
@@ -1,8 +1,11 @@
 package com.justpickup.ownerapigatewayservice;
 
+import com.justpickup.ownerapigatewayservice.handler.GlobalExceptionHandler;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableEurekaClient
@@ -10,6 +13,11 @@ public class OwnerApigatewayServiceApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(OwnerApigatewayServiceApplication.class, args);
+	}
+
+	@Bean
+	public ErrorWebExceptionHandler globalExceptionHandler() {
+		return new GlobalExceptionHandler();
 	}
 
 }

--- a/owner-apigateway-service/src/main/java/com/justpickup/ownerapigatewayservice/filter/AuthorizationHeaderFilter.java
+++ b/owner-apigateway-service/src/main/java/com/justpickup/ownerapigatewayservice/filter/AuthorizationHeaderFilter.java
@@ -44,9 +44,7 @@ public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<Auth
             // JWT 토큰 판별
             String token = authorizationHeader.replace("Bearer", "");
 
-            if (!jwtTokenProvider.validateJwtToken(token)) {
-                return onError(exchange, "JWT token is not valid", HttpStatus.UNAUTHORIZED);
-            }
+            jwtTokenProvider.validateJwtToken(token);
 
             String subject = jwtTokenProvider.getUserId(token);
             if (false == jwtTokenProvider.getRoles(token).contains("StoreOwner")) {

--- a/owner-apigateway-service/src/main/java/com/justpickup/ownerapigatewayservice/handler/GlobalExceptionHandler.java
+++ b/owner-apigateway-service/src/main/java/com/justpickup/ownerapigatewayservice/handler/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.justpickup.ownerapigatewayservice.handler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+
+        Class<? extends Throwable> exceptionClass = ex.getClass();
+
+        Map<String, Object> responseBody = new HashMap<>();
+        if (exceptionClass == ExpiredJwtException.class) {
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+            responseBody.put("code", "EXPIRED");
+            responseBody.put("message", "Access Token is Expired!");
+        }
+
+        DataBuffer wrap = null;
+        try {
+            byte[] bytes = objectMapper.writeValueAsBytes(responseBody);
+            wrap = exchange.getResponse().bufferFactory().wrap(bytes);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        return exchange.getResponse().writeWith(Flux.just(wrap));
+    }
+}

--- a/owner-apigateway-service/src/main/java/com/justpickup/ownerapigatewayservice/security/JwtTokenProvider.java
+++ b/owner-apigateway-service/src/main/java/com/justpickup/ownerapigatewayservice/security/JwtTokenProvider.java
@@ -73,25 +73,12 @@ public class JwtTokenProvider {
         return (List<String>) getClaimsFromJwtToken(token).get("roles");
     }
 
-    public boolean validateJwtToken(String token) {
+    public void validateJwtToken(String token) {
         try {
             Jwts.parser().setSigningKey(SECRET).parseClaimsJws(token);
-            return true;
-        } catch (SignatureException e) {
-            log.error("Invalid JWT signature: {}", e.getMessage());
-            return false;
-        } catch (MalformedJwtException e) {
-            log.error("Invalid JWT token: {}", e.getMessage());
-            return false;
-        } catch (ExpiredJwtException e) {
-            log.error("JWT token is expired: {}", e.getMessage());
-            throw e;
-        } catch (UnsupportedJwtException e) {
-            log.error("JWT token is unsupported: {}", e.getMessage());
-            return false;
-        } catch (IllegalArgumentException e) {
-            log.error("JWT claims string is empty: {}", e.getMessage());
-            return false;
+        } catch (SignatureException  | MalformedJwtException |
+                UnsupportedJwtException | IllegalArgumentException | ExpiredJwtException jwtException) {
+            throw jwtException;
         }
     }
 

--- a/owner-apigateway-service/src/main/java/com/justpickup/ownerapigatewayservice/security/JwtTokenProvider.java
+++ b/owner-apigateway-service/src/main/java/com/justpickup/ownerapigatewayservice/security/JwtTokenProvider.java
@@ -85,7 +85,7 @@ public class JwtTokenProvider {
             return false;
         } catch (ExpiredJwtException e) {
             log.error("JWT token is expired: {}", e.getMessage());
-            return false;
+            throw e;
         } catch (UnsupportedJwtException e) {
             log.error("JWT token is unsupported: {}", e.getMessage());
             return false;

--- a/owner-apigateway-service/src/main/resources/application.yml
+++ b/owner-apigateway-service/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
       globalcors:
         cors-configurations:
           '[/**]':
-            allowedOrigins: "*"
+            allowedOrigins: "http://localhost:8080"
             allowedMethods:
               - GET
               - POST
@@ -25,6 +25,7 @@ spring:
               - PUT
               - OPTIONS
             allowedHeaders: '*'
+            allow-credentials: true
       routes:
         - id: owner-frontend-service
           uri: lb://OWNER-FRONTEND-SERVICE
@@ -32,18 +33,22 @@ spring:
             - Path=/owner-frontend-service/**
           filters:
             - RewritePath=/owner-frontend-service/(?<segment>.*),/$\{segment}
+
         - id: order-service
           uri: lb://ORDER-SERVCIE
           predicates:
             - Path=/order-service/**
           filters:
             - RewritePath=/order-service/(?<segment>.*),/$\{segment}
+            - AuthorizationHeaderFilter
+
         - id: store-service
           uri: lb://STORE-SERVCIE
           predicates:
             - Path=/store-service/**
           filters:
             - RewritePath=/store-service/(?<segment>.*),/$\{segment}
+
         - id: user-service
           uri: lb://USER-SERVICE
           predicates:
@@ -54,7 +59,7 @@ spring:
         - id: user-service
           uri: lb://USER-SERVICE
           predicates:
-            - Path=/user-service/refreshToken
+            - Path=/user-service/auth/reissue
             - Method=GET
           filters:
             - RewritePath=/user-service/(?<segment>.*),/$\{segment}
@@ -78,6 +83,7 @@ spring:
             - Path=/user-service/**
           filters:
             - RewritePath=/user-service/(?<segment>.*),/$\{segment}
+            - AuthorizationHeaderFilter
 
 token:
   access-expired-time: 3600000

--- a/owner-vue/src/api/auth.js
+++ b/owner-vue/src/api/auth.js
@@ -1,0 +1,26 @@
+import axios from "axios";
+import jwt from "@/common/jwt";
+
+export default {
+  async requestReissue() {
+    const config = {
+      headers: {
+        "X-AUTH-TOKEN": jwt.getToken()
+      }
+    }
+
+    const res = await axios.get("http://localhost:8001/user-service/auth/reissue", config);
+
+    const accessToken = res.data.data.accessToken;
+    jwt.saveToken(accessToken);
+    jwt.saveExpiredTime(res.data.data.expiredTime);
+    axios.defaults.headers.common['Authorization'] =  "Bearer " + accessToken;
+
+    return accessToken;
+  },
+  requestCheckAccessToken() {
+    axios.defaults.headers.common['Authorization'] =  "Bearer " + jwt.getToken();
+
+    return axios.get("http://localhost:8001/user-service/auth/check/accessToken");
+  }
+}

--- a/owner-vue/src/api/auth.js
+++ b/owner-vue/src/api/auth.js
@@ -21,6 +21,6 @@ export default {
   requestCheckAccessToken() {
     axios.defaults.headers.common['Authorization'] =  "Bearer " + jwt.getToken();
 
-    return axios.get("http://localhost:8001/user-service/auth/check/accessToken");
+    return axios.get("http://localhost:8001/user-service/auth/check/access-token");
   }
 }

--- a/owner-vue/src/api/user.js
+++ b/owner-vue/src/api/user.js
@@ -1,3 +1,5 @@
+import jwt from '../common/jwt.js';
+
 export default {
   requestRegisterUser(user) {
     return axios.post("http://localhost:8001/user-service/store-owner", user);
@@ -11,10 +13,12 @@ export default {
 
     try {
       const response = await axios.post("http://localhost:8001/user-service/login", user);
-      console.log(response);
-      const AUTH_TOKEN = response.data.data.access_token;
-      localStorage.setItem('access_token', AUTH_TOKEN);
-      axios.defaults.headers.common['Authorization'] =  AUTH_TOKEN;
+      const data = response.data.data;
+
+      jwt.saveToken(data.accessToken);
+      jwt.saveExpiredTime(data.expiredTime);
+
+      axios.defaults.headers.common['Authorization'] =  "Bearer " + data.accessToken;
 
       return true;
     } catch (err) {

--- a/owner-vue/src/api/user.js
+++ b/owner-vue/src/api/user.js
@@ -1,8 +1,30 @@
-import axios from "axios";
-
 export default {
+  requestRegisterUser(user) {
+    return axios.post("http://localhost:8001/user-service/store-owner", user);
+  },
 
-    requestRegisterUser(user) {
-        return axios.post("http://localhost:8001/user-service/store-owner", user);
+  async requestLoginUser(email, password) {
+    const user = {
+      email: email,
+      password: password
     }
+
+    try {
+      const response = await axios.post("http://localhost:8001/user-service/login", user);
+      console.log(response);
+      const AUTH_TOKEN = response.data.data.access_token;
+      localStorage.setItem('access_token', AUTH_TOKEN);
+      axios.defaults.headers.common['Authorization'] =  AUTH_TOKEN;
+
+      return true;
+    } catch (err) {
+      console.log("Error = ", err);
+      alert("로그인 실패!");
+
+      return false;
+    }
+
+  }
 }
+
+import axios from "axios";

--- a/owner-vue/src/api/user.js
+++ b/owner-vue/src/api/user.js
@@ -23,8 +23,6 @@ export default {
       return true;
     } catch (err) {
       console.log("Error = ", err);
-      alert("로그인 실패!");
-
       return false;
     }
 

--- a/owner-vue/src/common/jwt.js
+++ b/owner-vue/src/common/jwt.js
@@ -1,0 +1,38 @@
+
+const moment = require('moment');
+const ACCESS_TOKEN_NAME = "accessToken";
+const EXPIRED_TIME_NAME = "expiredTime";
+
+const tag = "[jwt]";
+
+export default {
+  getToken() {
+    return localStorage.getItem(ACCESS_TOKEN_NAME);
+  },
+  saveToken(token) {
+    localStorage.setItem(ACCESS_TOKEN_NAME, token);
+  },
+  getExpiredTime() {
+    return localStorage.getItem(EXPIRED_TIME_NAME);
+  },
+  saveExpiredTime(expiredTime) {
+    localStorage.setItem(EXPIRED_TIME_NAME, expiredTime);
+  },
+  destroyAll() {
+    localStorage.removeItem(ACCESS_TOKEN_NAME);
+    localStorage.removeItem(EXPIRED_TIME_NAME);
+  },
+  isExpired() {
+    const expiredTime = this.getExpiredTime();
+
+    const expiredMoment = moment(expiredTime);
+    let currentMoment = moment();
+
+    const difference = moment.duration(expiredMoment.diff(currentMoment)).asSeconds();
+
+    console.log(tag, "expireMoment = ", expiredMoment, "currentMoment = ", currentMoment, "diff = ", difference);
+
+    // 만료 30초 전일 경우 만료로 판단
+    return difference <= 30;
+  }
+}

--- a/owner-vue/src/main.js
+++ b/owner-vue/src/main.js
@@ -1,7 +1,11 @@
-import Vue from 'vue'
-import App from './App.vue'
-import vuetify from './plugins/vuetify'
-import router from './router'
+import Vue from 'vue';
+import App from './App.vue';
+import vuetify from './plugins/vuetify';
+import router from './router';
+import axios from "axios";
+import auth from "./api/auth.js"
+
+axios.defaults.withCredentials = true;
 
 Vue.config.productionTip = false
 
@@ -10,3 +14,32 @@ new Vue({
   router,
   render: h => h(App)
 }).$mount('#app')
+
+axios.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+      try {
+        const originalRequest = error.config;
+        if (error.response.status === 401) {
+          // access token 만료 시
+          if (error.response.data.code == "EXPIRED") {
+            const accessToken = await auth.requestReissue();
+
+            originalRequest.headers.Authorization = "Bearer " + accessToken;
+            return axios(originalRequest);
+          }
+          // 그외 에러일 시
+          alert("로그인 정보가 일치하지 않습니다.");
+          await router.replace('/login');
+          return;
+        }
+      } catch (error) {
+          alert("로그인 정보가 일치하지 않습니다.");
+          await router.replace('/login');
+          return;
+      }
+    return Promise.reject(error);
+  }
+);

--- a/owner-vue/src/main.js
+++ b/owner-vue/src/main.js
@@ -3,7 +3,7 @@ import App from './App.vue';
 import vuetify from './plugins/vuetify';
 import router from './router';
 import axios from "axios";
-import auth from "./api/auth.js"
+import auth from "./api/auth.js";
 
 axios.defaults.withCredentials = true;
 
@@ -20,26 +20,23 @@ axios.interceptors.response.use(
     return response;
   },
   async (error) => {
-      try {
-        const originalRequest = error.config;
-        if (error.response.status === 401) {
-          // access token 만료 시
-          if (error.response.data.code == "EXPIRED") {
-            const accessToken = await auth.requestReissue();
-
-            originalRequest.headers.Authorization = "Bearer " + accessToken;
-            return axios(originalRequest);
-          }
-          // 그외 에러일 시
-          alert("로그인 정보가 일치하지 않습니다.");
-          await router.replace('/login');
-          return;
+    const originalRequest = error.config;
+    if (error.response.status === 401) {
+      let code = error.response.data.code;
+      if (code === "EXPIRED") {
+        console.log("## expired");
+        try {
+          const accessToken = await auth.requestReissue();
+          originalRequest.headers.Authorization = "Bearer " + accessToken;
+          return axios(originalRequest);
+        } catch (reissueError) {
+          window.location.href = "http://localhost:8080";
+          alert("권한이 없습니다. 다시 로그인 해주세요");
         }
-      } catch (error) {
-          alert("로그인 정보가 일치하지 않습니다.");
-          await router.replace('/login');
-          return;
-      }
+       }
+      window.location.href = "http://localhost:8080";
+      alert("권한이 없습니다. 다시 로그인해주세요.");
+    }
     return Promise.reject(error);
   }
 );

--- a/owner-vue/src/router/index.js
+++ b/owner-vue/src/router/index.js
@@ -4,13 +4,30 @@ import VueRouter from 'vue-router'
 import DashboardLayout from "@/views/Layout/DashboardLayout";
 import AuthLayout from "@/views/Layout/AuthLayout";
 
+import jwt from "../common/jwt.js";
+import auth from "../api/auth.js";
+
 Vue.use(VueRouter)
 
+const authCheck = async function (to, from, next) {
+  try {
+    if (jwt.isExpired()) {
+      // refresh 호출
+      await auth.requestReissue();
+    } else {
+      await auth.requestCheckAccessToken();
+    }
+  } catch (error) {
+    await router.replace("/login");
+  }
+  next();
+};
 const routes = [
   {
     path: '/dashboard',
     redirect: 'dashboard',
     component: DashboardLayout,
+    beforeEnter: authCheck,
     children: [
       {
         path: "/dashboard",

--- a/owner-vue/src/views/LoginUser.vue
+++ b/owner-vue/src/views/LoginUser.vue
@@ -1,0 +1,61 @@
+<template>
+  <v-card width="800" class="mx-auto mt-5">
+    <v-card-title>
+      <h1>Login</h1>
+    </v-card-title>
+    <v-card-text>
+      <v-form ref="form" lazy-validation>
+        <v-text-field
+            v-model="email"
+            :rules="[v => /.+@.+\..+/.test(v) || 'E-mail must be valid', v => !!v || '이메일은 필수 값입니다']"
+            label="이메일"
+            prepend-icon="mdi-account-circle"
+        ></v-text-field>
+        <v-text-field
+            v-model="password"
+            :rules="[v => !!v || '비밀번호는 필수 값입니다']"
+            label="비밀번호"
+            type="Password"
+            prepend-icon="mdi-lock"
+            append-icon="mdi-eye-off"
+        ></v-text-field>
+      </v-form>
+    </v-card-text>
+    <v-divider></v-divider>
+    <v-card-actions>
+      <v-btn color="success" v-on:click="links('/register')">Register</v-btn>
+      <v-spacer></v-spacer>
+      <v-btn color="info" v-on:click="login">Login</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script>
+import userApi from '../api/user.js'
+
+export default {
+  name: "LoginUser",
+  data: function() {
+    return {
+      email: 'owner@gmail.com',
+      password: '1234'
+    }
+  },
+  methods: {
+    links: function(url) {
+      this.$router.push(url);
+    },
+    login: async function() {
+      if (!this.$refs.form.validate()) return;
+
+      const flag = await userApi.requestLoginUser(this.email, this.password);
+
+      if (flag) await this.$router.push('/prev-order');
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/user-service/src/main/java/com/justpickup/userservice/domain/jwt/exception/AccessTokenNotValidException.java
+++ b/user-service/src/main/java/com/justpickup/userservice/domain/jwt/exception/AccessTokenNotValidException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class AccessTokenNotValidException extends CustomException {
 
     public AccessTokenNotValidException(String message) {
-        super(HttpStatus.FORBIDDEN, message);
+        super(HttpStatus.UNAUTHORIZED, message);
     }
 }

--- a/user-service/src/main/java/com/justpickup/userservice/domain/jwt/service/AccessTokenService.java
+++ b/user-service/src/main/java/com/justpickup/userservice/domain/jwt/service/AccessTokenService.java
@@ -1,0 +1,6 @@
+package com.justpickup.userservice.domain.jwt.service;
+
+public interface AccessTokenService {
+
+    void checkAccessToken(String authorizationHeader);
+}

--- a/user-service/src/main/java/com/justpickup/userservice/domain/jwt/service/AccessTokenServiceImpl.java
+++ b/user-service/src/main/java/com/justpickup/userservice/domain/jwt/service/AccessTokenServiceImpl.java
@@ -1,0 +1,23 @@
+package com.justpickup.userservice.domain.jwt.service;
+
+import com.justpickup.userservice.domain.jwt.exception.AccessTokenNotValidException;
+import com.justpickup.userservice.global.utils.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccessTokenServiceImpl implements AccessTokenService {
+
+    private final JwtTokenProvider tokenProvider;
+
+    @Override
+    public void checkAccessToken(String authorizationHeader) {
+
+        String token = authorizationHeader.replace("Bearer", "");
+
+        if (!tokenProvider.validateJwtToken(token)) {
+            throw new AccessTokenNotValidException("Access Token is not Valid");
+        }
+    }
+}

--- a/user-service/src/main/java/com/justpickup/userservice/domain/jwt/service/RefreshTokenServiceImpl.java
+++ b/user-service/src/main/java/com/justpickup/userservice/domain/jwt/service/RefreshTokenServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -69,9 +70,11 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
                 .stream().map(GrantedAuthority::getAuthority).collect(Collectors.toList());
 
         String newAccessToken = jwtTokenProvider.createJwtAccessToken(userId, "/refreshToken", roles);
+        Date expiredTime = jwtTokenProvider.getExpiredTime(newAccessToken);
 
         return JwtTokenDto.builder()
                 .accessToken(newAccessToken)
+                .accessTokenExpiredDate(expiredTime)
                 .refreshToken(refreshToken)
                 .build();
     }

--- a/user-service/src/main/java/com/justpickup/userservice/domain/user/dto/JwtTokenDto.java
+++ b/user-service/src/main/java/com/justpickup/userservice/domain/user/dto/JwtTokenDto.java
@@ -3,14 +3,18 @@ package com.justpickup.userservice.domain.user.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Date;
+
 @Getter
 public class JwtTokenDto {
     private String accessToken;
+    private Date accessTokenExpiredDate;
     private String refreshToken;
 
     @Builder
-    public JwtTokenDto(String accessToken, String refreshToken) {
+    public JwtTokenDto(String accessToken, String refreshToken, Date accessTokenExpiredDate) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+        this.accessTokenExpiredDate = accessTokenExpiredDate;
     }
 }

--- a/user-service/src/main/java/com/justpickup/userservice/global/exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/com/justpickup/userservice/global/exception/GlobalExceptionHandler.java
@@ -36,7 +36,7 @@ public class GlobalExceptionHandler {
         // 쿠키 삭제
         ResponseCookie responseCookie = cookieProvider.removeRefreshTokenCookie();
 
-        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
                 .body(e.getResult());
     }

--- a/user-service/src/main/java/com/justpickup/userservice/global/utils/JwtTokenProvider.java
+++ b/user-service/src/main/java/com/justpickup/userservice/global/utils/JwtTokenProvider.java
@@ -5,10 +5,6 @@ import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
@@ -57,8 +53,6 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-
-
     public String getUserId(String token) {
         return getClaimsFromJwtToken(token).getSubject();
     }
@@ -73,6 +67,10 @@ public class JwtTokenProvider {
 
     public String getRefreshTokenId(String token) {
         return getClaimsFromJwtToken(token).get("value").toString();
+    }
+
+    public Date getExpiredTime(String token) {
+        return getClaimsFromJwtToken(token).getExpiration();
     }
 
     public List<String> getRoles(String token) {


### PR DESCRIPTION
## What is this PR? :mag:
- 점주 로그인 페이지 및 로직이 추가되었습니다.
- jwt의 access token 및 refresh token을 통한 인증이 구현되었습니다.
- vue router를 이용하여 페이지 이동 시 jwt 검증 로직이 추가되었습니다.
- axios interceptor를 이용한 jwt 검증 로직이 추가되었습니다.
- owner api gateway에 with Credential 설정이 추가되었습니다.
- access token url 매핑 부분 404 NotFound 에러 해결

## Changes :memo:
1. access token 만료
    ![image](https://user-images.githubusercontent.com/72686708/155945797-d091463b-1ea5-416a-b265-eff52d811c7b.png)
2. refresh token을 이용하여 access token 재발급
    ![image](https://user-images.githubusercontent.com/72686708/155945910-fc40c56d-f552-4e03-9835-b0f6d639889b.png)
3. 정상 호출
    ![image](https://user-images.githubusercontent.com/72686708/155946432-d71b3670-4684-47b4-80b3-174a63e55889.png)

## Screenshot :camera:
기능|스크린샷|
|------|---|
|네트워크|![image](https://user-images.githubusercontent.com/72686708/155945663-aa7c63f9-6a34-489f-85da-c4fc0b0e4cc8.png)|
|로그인|![image](https://user-images.githubusercontent.com/72686708/155946531-e0d5cf0c-e5b3-4d89-81ec-9e9af4ecdfc8.png)|

## Test Checklist ☑️
- [ ] jwt access token 만료 시 reissue 호출
- [ ] jwt 토큰 이상 일 시 login 페이지로 리다이렉션 여부
- [ ] 로그인 성공 시 localStorag의 access token과 expired time 쿠키의 refresh-token 저장 여부