### PR TITLE
고객 검색 - 즐겨찾기 개수

### DIFF
--- a/customer-vue/src/views/SearchStore.vue
+++ b/customer-vue/src/views/SearchStore.vue
@@ -33,7 +33,16 @@
           ></v-img>
           <v-card-title>{{ card.name }}</v-card-title>
           <v-card-text>
-            거리 : {{ card.distance }}
+            <v-row>
+              <div class="orange--text ms-4">
+                <v-icon color="orange" dense>mdi-heart</v-icon>
+                {{ card.favoriteCounts }}
+              </div>
+              <div class="grey--text ms-4">
+                <v-icon dense>mdi-map-marker</v-icon>
+                {{ card.distance }}
+              </div>
+            </v-row>
           </v-card-text>
         </v-card>
       </v-col>
@@ -132,9 +141,10 @@ export default {
 
       stores.forEach( (store) => {
         this.cards.push({
-          storeId: store.storeId,
+          storeId: store.id,
           name: store.name,
-          distance: store.distance
+          distance: store.distance,
+          favoriteCounts: store.favoriteCounts
         })
       });
     }

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/favoritestore/repository/FavoriteStoreCustom.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/favoritestore/repository/FavoriteStoreCustom.java
@@ -1,0 +1,22 @@
+package com.justpickup.storeservice.domain.favoritestore.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.justpickup.storeservice.domain.favoritestore.entity.QFavoriteStore.favoriteStore;
+
+@Repository
+@RequiredArgsConstructor
+public class FavoriteStoreCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Long countFavoriteStoreByStoreId(Long storeId) {
+        return queryFactory.select(favoriteStore.count())
+                .from(favoriteStore)
+                .join(favoriteStore.store)
+                .where(favoriteStore.store.id.eq(storeId))
+                .fetchOne();
+    }
+}

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/store/dto/SearchStoreResult.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/store/dto/SearchStoreResult.java
@@ -10,6 +10,17 @@ public class SearchStoreResult {
     private Long storeId;
     private String storeName;
     private Double distanceMeter;
+    private Long favoriteCounts;
+
+    public SearchStoreResult(Long storeId, String storeName, Double distanceMeter) {
+        this.storeId = storeId;
+        this.storeName = storeName;
+        this.distanceMeter = distanceMeter;
+    }
+
+    public void setFavoriteCounts(Long favoriteCounts) {
+        this.favoriteCounts = favoriteCounts;
+    }
 
     public String convertDistanceToString() {
         // km 으로 표시
@@ -23,4 +34,5 @@ public class SearchStoreResult {
         // ex) 621m
         return new DecimalFormat("0").format(distanceMeter) + "m";
     }
+
 }

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/store/service/StoreServiceImpl.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/store/service/StoreServiceImpl.java
@@ -1,5 +1,6 @@
 package com.justpickup.storeservice.domain.store.service;
 
+import com.justpickup.storeservice.domain.favoritestore.repository.FavoriteStoreCustom;
 import com.justpickup.storeservice.domain.store.dto.SearchStoreCondition;
 import com.justpickup.storeservice.domain.store.dto.SearchStoreResult;
 import com.justpickup.storeservice.domain.store.repository.StoreRepositoryCustom;
@@ -13,9 +14,18 @@ import org.springframework.stereotype.Service;
 public class StoreServiceImpl implements StoreService {
 
     private final StoreRepositoryCustom storeRepositoryCustom;
+    private final FavoriteStoreCustom favoriteStoreCustom;
 
     @Override
     public SliceImpl<SearchStoreResult> findSearchStoreScroll(SearchStoreCondition condition, Pageable pageable) {
-        return storeRepositoryCustom.findSearchStoreScroll(condition, pageable);
+        SliceImpl<SearchStoreResult> searchStoreScroll =
+                storeRepositoryCustom.findSearchStoreScroll(condition, pageable);
+
+        searchStoreScroll.forEach(result -> {
+            Long favoriteCounts = favoriteStoreCustom.countFavoriteStoreByStoreId(result.getStoreId());
+            result.setFavoriteCounts(favoriteCounts);
+        });
+
+        return searchStoreScroll;
     }
 }

--- a/store-service/src/main/java/com/justpickup/storeservice/domain/store/web/StoreController.java
+++ b/store-service/src/main/java/com/justpickup/storeservice/domain/store/web/StoreController.java
@@ -48,13 +48,15 @@ public class StoreController {
             private Long id;
             private String name;
             private String distance;
+            private Long favoriteCounts;
         }
 
         public SearchStoreResponse(List<SearchStoreResult> content, boolean hasNext) {
             this.stores = content.stream()
                     .map(result ->
                             new StoreDto(
-                                    result.getStoreId(), result.getStoreName(), result.convertDistanceToString())
+                                    result.getStoreId(), result.getStoreName(),
+                                    result.convertDistanceToString(), result.getFavoriteCounts())
                     )
                     .collect(Collectors.toList());
             this.hasNext = hasNext;

--- a/store-service/src/test/java/com/justpickup/storeservice/domain/store/web/StoreControllerTest.java
+++ b/store-service/src/test/java/com/justpickup/storeservice/domain/store/web/StoreControllerTest.java
@@ -81,6 +81,7 @@ class StoreControllerTest {
                                 fieldWithPath("data.stores[*].id").description("매장 고유번호"),
                                 fieldWithPath("data.stores[*].name").description("매장 이름"),
                                 fieldWithPath("data.stores[*].distance").description("고객과의 거리차이 m/km"),
+                                fieldWithPath("data.stores[*].favoriteCounts").description("매장 즐겨찾기 수"),
                                 fieldWithPath("data.hasNext").description("더보기 버튼 유무")
                         )
                         ))


### PR DESCRIPTION
## What is this PR? :mag:
- 고객 검색 페이지 즐겨찾기 개수가 추가되었습니다.

## Changes :memo:
- 매장 카드의 거리와 즐겨찾기 아이콘이 변경되었습니다.


## Screenshot :camera:
기능|스크린샷|
|------|---|
|화면|![image](https://user-images.githubusercontent.com/72686708/156734774-cb91755a-0814-4520-aa1d-f76edb20e9b4.png)|

## Test Checklist ☑️
- [x] 즐겨찾기 개수 정상 출력 여부